### PR TITLE
[docs] Package should be installed as --dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 You can install the package via composer:
 
 ```bash
-composer require claudiodekker/inertia-laravel-testing
+composer require --dev claudiodekker/inertia-laravel-testing
 ```
 
 ## Usage


### PR DESCRIPTION
We want it for testing, so it should be `--dev` only, right?