### PR TITLE
Bump Inertia version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "inertiajs/inertia-laravel": "^v0.2.8",
+        "inertiajs/inertia-laravel": "^v0.3",
         "laravel/framework": "^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi there 👋 Thanks for releasing these Inertia test helpers! 

Had some issues installing using Composer due to the version specified in `composer.json`, this PR simply bumps to `^v0.3` which got it working for me when requiring locally.

Let me know if you have any questions!

---

For context, here's the error I was getting:

```
$ composer require --dev claudiodekker/inertia-laravel-testing
Using version ^1.1 for claudiodekker/inertia-laravel-testing
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for claudiodekker/inertia-laravel-testing ^1.1 -> satisfiable by claudiodekker/inertia-laravel-testing[1.1.0].
    - claudiodekker/inertia-laravel-testing 1.1.0 requires inertiajs/inertia-laravel ^v0.2.8 -> satisfiable by inertiajs/inertia-laravel[v0.2.10, v0.2.11, v0.2.12, v0.2.13, v0.2.14, v0.2.15, v0.2.8, v0.2.9] but these conflict with your requirements or minimum-stability.


Installation failed, reverting ./composer.json to its original content.
```