### PR TITLE
Orchestra Testbench: Instructions to register Service Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ You can install the package via composer:
 composer require --dev claudiodekker/inertia-laravel-testing
 ```
 
+### Orchestral Testbench
+In case you are using `orchestra/testbench` loading the `InertiaTestingServiceProvider` is required in your `TestCase`.
+
+```php
+<?php
+
+
+class TestCase extends Orchestra\Testbench\TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+                  // Add your custom service providers
+                  // .... 
+                  // Inertia testing provider
+                  'ClaudioDekker\Inertia\InertiaTestingServiceProvider'
+                ];
+    }
+}
+```
+
 ## Usage
 
 To test, simply chain any of the following methods onto your `TestResponse` responses.


### PR DESCRIPTION
For laravel package development `orchestra/testbench` is often used. Normally the service provider are automatically registered in a laravel app, however in package testing one must manually register the serviceprovider in the `getPackageProviders` method of the TestCase. Without it, the assertions of this package will not be registered and cause the tests to run into exceptions. 

This short information on the installation notes will remind every herp-derp (just like me :smile: ) to not forget to register the ServiceProvider.

If you do not like to have such an explicit instruction, i would advice to note that the ServiceProvider needs to be registered to successfully run tests with the inertia assertions. 