### PR TITLE
Adds support for count test

### DIFF
--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -13,6 +13,7 @@ namespace Illuminate\Testing {
      * @method self assertInertiaHas($key, $value = null)
      * @method self assertInertiaHasAll(array $bindings)
      * @method self assertInertiaMissing($key)
+     * @method self assertInertiaCount($key, $count)
      * @method array|mixed inertiaProps($key = null)
      */
     class TestResponse

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -81,6 +81,17 @@ class Assertions
         };
     }
 
+    public function assertInertiaCount()
+    {
+        return function ($key, $count) {
+            $this->assertInertia();
+
+            PHPUnit::assertCount($count, Arr::get($this->inertiaProps(), $key, []));
+
+            return $this;
+        };
+    }
+
     public function inertiaProps()
     {
         return function ($key = null) {

--- a/tests/Unit/AssertionsTest.php
+++ b/tests/Unit/AssertionsTest.php
@@ -527,6 +527,72 @@ class AssertionsTest extends TestCase
         $this->assertNull($response->inertiaProps('foo.bar'));
     }
 
+    public function test_the_inertia_page_is_matching_count()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'nested' => 'value',
+                    'other' => 'value',
+                ],
+            ])
+        );
+
+        $response->assertInertiaCount('baz', 2);
+    }
+
+    public function test_the_inertia_page_with_nested_key_is_matching_count()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'nested' => [
+                        'flim' => 'value',
+                        'flam' => 'value',
+                    ],
+                ],
+            ])
+        );
+
+        $response->assertInertiaCount('baz.nested', 2);
+    }
+
+    public function test_the_inertia_page_is_not_matching_count()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'nested' => 'value',
+                    'other' => 'value',
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaCount('baz', 3);
+    }
+
+    public function test_the_inertia_page_fails_count_on_missing_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'nested' => 'value',
+                    'other' => 'value',
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaCount('invalid', 2);
+    }
+
     private function makeMockResponse($view)
     {
         app('router')->get('/', function () use ($view) {


### PR DESCRIPTION
This PR adds support for a `->assertInertiaCount($key, $count)` test method.

Often you want to be able to test that the correct data is being returned to the browser based on filtering criteria. This new method functions like the others with a simple key / comparison signature.

```php
// Base

$this->get(route('locations.index'))
    ->assertInertia('Locations/Index')
    ->assertInertiaHas('locations')
    ->assertInertiaCount('locations', 5);

// Filtered

$query = http_build_query(['province' => 'ON']);

$this->get(route('locations.index')."?{$query}")
    ->assertInertia('Locations/Index')
    ->assertInertiaHas('locations')
    ->assertInertiaCount('locations', 2);
```