### PR TITLE
Fix documentation: replace assertCount with assertInertiaCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ $response->assertInertiaMissing('deeply.nested.key');
 
 Assert whether a specific property has the correct count of records
 ```php
-$response->assertCount('key', $count);
+$response->assertInertiaCount('key', $count);
 
 // or, for deeply nested values
-$response->assertCount('deeply.nested.key', $count);
+$response->assertInertiaCount('deeply.nested.key', $count);
 ```
 
 


### PR DESCRIPTION
I think the intention of this section is to use the assertInertiaCount assertion, but the php assertCount is mentioned, which shouldn't be correct.