### PR TITLE
Add ability to Macro the Assert class

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -8,12 +8,15 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\AssertionFailedError;
 
 class Assert
 {
+    use Macroable;
+
     /** @var string */
     private $component;
 

--- a/src/Macros/VarDumper.php
+++ b/src/Macros/VarDumper.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ClaudioDekker\Inertia\Macros;
+
+/**
+ * This class can be used by mixin it in:
+ *   Assert::mixin(new VarDumper());.
+ *
+ * @see ClaudioDekker\Inertia\Assert
+ */
+class VarDumper
+{
+    public function dd()
+    {
+        return function (string $prop = null) {
+            dd($this->prop($prop));
+        };
+    }
+
+    public function dump()
+    {
+        return function (string $prop = null) {
+            dump($this->prop($prop));
+
+            return $this;
+        };
+    }
+}

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -4,6 +4,7 @@ namespace ClaudioDekker\Inertia\Tests\Unit;
 
 use ClaudioDekker\Inertia\Assert;
 use ClaudioDekker\Inertia\Tests\TestCase;
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -1056,6 +1057,25 @@ class AssertTest extends TestCase
 
         $response->assertInertia(function (Assert $inertia) {
             $inertia->version('different-version');
+        });
+    }
+
+    /** @test */
+    public function it_is_macroable(): void
+    {
+        Assert::macro('myCustomMacro', function () {
+            throw new Exception('My Custom Macro was called!');
+        });
+
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('My Custom Macro was called!');
+
+        $response->assertInertia(function (Assert $inertia) {
+            $inertia->myCustomMacro();
         });
     }
 }


### PR DESCRIPTION
This PR adds the ability to register Macros on the `Assert` class.

As an useful example, it also adds a `dump` and `dd` macro that can be registered by calling
 `Assert::mixin(new VarDumper());`