### PR TITLE
Add & prefer 'missing' & 'missingAll' methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ $response->assertInertia(fn (Assert $inertia) => $inertia
             ->where('name', 'Claudio Dekker')
             ->where('platform', 'Apple Podcasts')
             ->etc()
-            ->misses('email')
-            ->misses('password')
+            ->missing('email')
+            ->missing('password')
         )
     )
 );
@@ -90,12 +90,12 @@ In-depth:
 - [`where`](#where)
     - [Using a Closure](#using-a-closure)
 - [`etc`](#etc)
-    - [`misses`](#misses)
+    - [`missing`](#missing)
 
 Reducing verbosity (multiple assertions):
 - [`has`](#has-1)
 - [`where`](#where-1)
-- [`misses`](#misses-1)
+- [`missing`](#missing-1)
 
 ---
 
@@ -314,22 +314,22 @@ $response->assertInertia(fn (Assert $inertia) => $inertia
 > middle of your assertions does not change how it behaves: It will disable the automatic check that asserts that all properties
 > in the current scope have been interacted with.
 
-### `misses`
-Because `misses` isn't necessary by default, it provides a great solution when using `etc`. 
+### `missing`
+Because `missing` isn't necessary by default, it provides a great solution when using `etc`. 
 
 In short, it does the exact opposite of the `has` method, ensuring that the property does _not exist_:
 ```php
 $response->assertInertia(fn (Assert $inertia) => $inertia
     ->has('message', fn (Assert $inertia) => $inertia
         ->has('subject')
-        ->misses('published_at')
+        ->missing('published_at')
         ->etc()
     )
 );
 ```
 
 ## Reducing verbosity
-To reduce the amount of `where`, `has` or `misses` calls, there are a couple of convenience methods that allow you to
+To reduce the amount of `where`, `has` or `missing` calls, there are a couple of convenience methods that allow you to
 make these same assertions in a slightly less-verbose looking way. Do note that these methods do not make your assertions
 any faster, and really only exist to help you reduce your test's visual complexity.
 
@@ -390,8 +390,8 @@ $response->assertInertia(fn (Assert $inertia) => $inertia
 );
 ```
 
-### `misses`
-Instead of making multiple `misses` call, you may use `missesAll` instead. 
+### `missing`
+Instead of making multiple `missing` call, you may use `missingAll` instead. 
 
 Similar to basic `hasAll` usage, this assertion accepts both a single array or a list of arguments, at which point it 
 will assert that the given props do not exist:
@@ -399,17 +399,17 @@ will assert that the given props do not exist:
 ```php
 $response->assertInertia(fn (Assert $inertia) => $inertia
     // Before
-    ->misses('subject')
-    ->misses('user.name')
+    ->missing('subject')
+    ->missing('user.name')
 
     // After
-    ->missesAll([
+    ->missingAll([
         'subject',
         'user.name',
     ])
 
     // Alternative
-    ->missesAll('subject', 'user.name')
+    ->missingAll('subject', 'user.name')
 );
 ```
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -208,7 +208,7 @@ class Assert
         return $this;
     }
 
-    public function missesAll($key): self
+    public function missingAll($key): self
     {
         $keys = is_array($key) ? $key : func_get_args();
 
@@ -219,7 +219,7 @@ class Assert
         return $this;
     }
 
-    public function misses(string $key): self
+    public function missing(string $key): self
     {
         $this->interactsWith($key);
 
@@ -229,6 +229,18 @@ class Assert
         );
 
         return $this;
+    }
+
+    public function missesAll($key): self
+    {
+        return $this->missingAll(
+            is_array($key) ? $key : func_get_args()
+        );
+    }
+
+    public function misses(string $key): self
+    {
+        return $this->missing($key);
     }
 
     public function whereAll(array $bindings): self

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -304,12 +304,28 @@ class AssertTest extends TestCase
         );
 
         $response->assertInertia(function (Assert $inertia) {
+            $inertia->missing('foo.baz');
+        });
+    }
+
+    /** @test */
+    public function it_asserts_that_a_prop_is_missing_using_the_misses_method(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'foo' => [
+                    'bar' => true,
+                ],
+            ])
+        );
+
+        $response->assertInertia(function (Assert $inertia) {
             $inertia->misses('foo.baz');
         });
     }
 
     /** @test */
-    public function it_fails_asserting_that_a_prop_is_missing_when_it_exists(): void
+    public function it_fails_asserting_that_a_prop_is_missing_when_it_exists_using_the_misses_method(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo', [
@@ -331,6 +347,28 @@ class AssertTest extends TestCase
     }
 
     /** @test */
+    public function it_fails_asserting_that_a_prop_is_missing_when_it_exists(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'prop' => 'value',
+                'foo' => [
+                    'bar' => true,
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia property [foo.bar] was found while it was expected to be missing.');
+
+        $response->assertInertia(function (Assert $inertia) {
+            $inertia
+                ->has('prop')
+                ->missing('foo.bar');
+        });
+    }
+
+    /** @test */
     public function it_can_assert_that_multiple_props_are_missing(): void
     {
         $response = $this->makeMockRequest(
@@ -342,7 +380,7 @@ class AssertTest extends TestCase
         $response->assertInertia(function (Assert $inertia) {
             $inertia
                 ->has('baz')
-                ->missesAll([
+                ->missingAll([
                     'foo',
                     'bar',
                 ]);
@@ -365,6 +403,72 @@ class AssertTest extends TestCase
         $response->assertInertia(function (Assert $inertia) {
             $inertia
                 ->has('foo')
+                ->missingAll([
+                    'bar',
+                    'baz',
+                ]);
+        });
+    }
+
+    /** @test */
+    public function it_can_use_arguments_instead_of_an_array_to_assert_that_it_is_missing_multiple_props(): void
+    {
+        $this->makeMockRequest(
+                Inertia::render('foo', [
+                    'baz' => 'foo',
+                ])
+        )->assertInertia(function (Assert $inertia) {
+            $inertia->has('baz')->missingAll('foo', 'bar');
+        });
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia property [baz] was found while it was expected to be missing.');
+
+        $this->makeMockRequest(
+            Inertia::render('foo', [
+                'foo' => 'bar',
+                'baz' => 'example',
+            ])
+        )->assertInertia(function (Assert $inertia) {
+            $inertia->has('foo')->missingAll('bar', 'baz');
+        });
+    }
+
+    /** @test */
+    public function it_can_assert_that_multiple_props_are_missing_using_the_misses_all_method(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'baz' => 'foo',
+            ])
+        );
+
+        $response->assertInertia(function (Assert $inertia) {
+            $inertia
+                ->has('baz')
+                ->missesAll([
+                    'foo',
+                    'bar',
+                ]);
+        });
+    }
+
+    /** @test */
+    public function it_cannot_assert_that_multiple_props_are_missing_when_at_least_one_exists_using_the_misses_all_method(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'foo' => 'bar',
+                'baz' => 'example',
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia property [baz] was found while it was expected to be missing.');
+
+        $response->assertInertia(function (Assert $inertia) {
+            $inertia
+                ->has('foo')
                 ->missesAll([
                     'bar',
                     'baz',
@@ -373,12 +477,12 @@ class AssertTest extends TestCase
     }
 
     /** @test */
-    public function it_can_use_arguments_instead_of_an_array_to_assert_that_it_misses_multiple_props(): void
+    public function it_can_use_arguments_instead_of_an_array_to_assert_that_it_is_missing_multiple_props_using_the_misses_all_method(): void
     {
         $this->makeMockRequest(
-                Inertia::render('foo', [
-                    'baz' => 'foo',
-                ])
+            Inertia::render('foo', [
+                'baz' => 'foo',
+            ])
         )->assertInertia(function (Assert $inertia) {
             $inertia->has('baz')->missesAll('foo', 'bar');
         });


### PR DESCRIPTION
This will add and prefer `missing` and `missesAll` over `misses` and `missesAll`, although both cases remain valid.