### PR TITLE
Fail when an unsupported second argument is provided to `has`

### DIFF
--- a/src/Concerns/Has.php
+++ b/src/Concerns/Has.php
@@ -5,6 +5,7 @@ namespace ClaudioDekker\Inertia\Concerns;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 trait Has
@@ -64,7 +65,11 @@ trait Has
         }
 
         if (is_callable($value)) {
-            $this->scope($key, $value);
+            return $this->scope($key, $value);
+        }
+
+        if (! is_null($value)) {
+            throw new InvalidArgumentException('The second argument of `has` is of an invalid type. Did you mean to use `where`?');
         }
 
         return $this;

--- a/src/Concerns/Has.php
+++ b/src/Concerns/Has.php
@@ -61,14 +61,10 @@ trait Has
         }
 
         if (is_int($value)) {
-            return $this->count($key, $value);
-        }
-
-        if (is_callable($value)) {
-            return $this->scope($key, $value);
-        }
-
-        if (! is_null($value)) {
+            $this->count($key, $value);
+        } elseif (is_callable($value)) {
+            $this->scope($key, $value);
+        } elseif (! is_null($value)) {
             throw new InvalidArgumentException('The second argument of `has` is of an invalid type. Did you mean to use `where`?');
         }
 

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
+use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
 
 class AssertTest extends TestCase
@@ -289,6 +290,23 @@ class AssertTest extends TestCase
 
         $response->assertInertia(function (Assert $inertia) {
             $inertia->has('baz', 2);
+        });
+    }
+
+    /** @test */
+    public function it_fails_when_the_second_argument_of_the_has_assertion_is_an_unsupported_type(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'bar' => 'baz',
+            ])
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The second argument of `has` is of an invalid type. Did you mean to use `where`?');
+
+        $response->assertInertia(function (Assert $inertia) {
+            $inertia->has('bar', 'invalid');
         });
     }
 


### PR DESCRIPTION
Currently, when making this mistake, no error is thrown and the test 'passes', essentially only checking that the prop is set. This PR fixes this behaviour, and throws an InvalidArgumentException when this occurs.